### PR TITLE
Making test runtime assemblies private assets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="xunit" Version="2.8" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.4" />
         <PackageVersion Include="nunit" Version="4.1" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="4.5" />
-        <PackageVersion Include="Microsoft.NET.Test.SDK" Version="16.11" />
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8" PrivateAssets="All" />
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.5" PrivateAssets="All" />
+        <PackageVersion Include="Microsoft.NET.Test.SDK" Version="16.11" PrivateAssets="All" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0" PrivateAssets="All"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Fixed

- Making assemblies used during running of tests private asset references, meaning that they are not dependencies for build and is then decided by the consumer of the package.
