### PR TITLE
Stop looking for root is type/baseType is null

### DIFF
--- a/Source/Specifications/SpecificationMethods.cs
+++ b/Source/Specifications/SpecificationMethods.cs
@@ -82,7 +82,7 @@ public static class SpecificationMethods<T, TSpecBase>
         var type = typeof(T);
         var methods = new List<MethodInfo>();
 
-        while (type != typeof(TSpecBase))
+        while (type != typeof(TSpecBase) && type is not null)
         {
             var method = type.GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
             if (method != null) methods.Insert(0, method);


### PR DESCRIPTION
### Fixed

- When walking the type hierarchy, if a type(baseType) is null it should stop and not try to invoke a Specification method
