### PR TITLE
Fix Release build and surface clear timeout diagnostic in lifecycle methods

### DIFF
--- a/Sample/Common/Roles.cs
+++ b/Sample/Common/Roles.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample;
 
 public static class Roles

--- a/Sample/Common/SecurityService.cs
+++ b/Sample/Common/SecurityService.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample;
 
 public class SecurityService

--- a/Sample/Common/UserMustBeSpecified.cs
+++ b/Sample/Common/UserMustBeSpecified.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample;
 
 public class UserMustBeSpecified : Exception

--- a/Sample/Common/UserToken.cs
+++ b/Sample/Common/UserToken.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample;
 
 public class UserToken

--- a/Sample/NUnit/GlobalUsings.cs
+++ b/Sample/NUnit/GlobalUsings.cs
@@ -1,2 +1,5 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 global using Cratis.Specifications;
 global using NUnit.Framework;

--- a/Sample/NUnit/for_SecurityService/given/no_user_authenticated.cs
+++ b/Sample/NUnit/for_SecurityService/given/no_user_authenticated.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityService.given;
 
 public class no_user_authenticated : Specification

--- a/Sample/NUnit/for_SecurityService/when_authenticating/a_null_user.cs
+++ b/Sample/NUnit/for_SecurityService/when_authenticating/a_null_user.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityService;
 
 public class When_authenticating_a_null_user : given.no_user_authenticated

--- a/Sample/NUnit/for_SecurityService/when_authenticating/an_admin_user.cs
+++ b/Sample/NUnit/for_SecurityService/when_authenticating/an_admin_user.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityService;
 
 public class When_authenticating_an_admin_user : given.no_user_authenticated

--- a/Sample/NUnit/for_SecurityServiceAsync/given/no_user_authenticated.cs
+++ b/Sample/NUnit/for_SecurityServiceAsync/given/no_user_authenticated.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityServiceAsync.given;
 
 public class no_user_authenticated : Specification

--- a/Sample/NUnit/for_SecurityServiceAsync/when_authenticating/a_null_user.cs
+++ b/Sample/NUnit/for_SecurityServiceAsync/when_authenticating/a_null_user.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityServiceAsync;
 
 public class When_authenticating_a_null_user : given.no_user_authenticated

--- a/Sample/NUnit/for_SecurityServiceAsync/when_authenticating/a_null_user_async.cs
+++ b/Sample/NUnit/for_SecurityServiceAsync/when_authenticating/a_null_user_async.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityServiceAsync;
 
 public class When_authenticating_a_null_user_async : given.no_user_authenticated

--- a/Sample/NUnit/for_SecurityServiceAsync/when_authenticating/an_admin_user.cs
+++ b/Sample/NUnit/for_SecurityServiceAsync/when_authenticating/an_admin_user.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityServiceAsync;
 
 public class When_authenticating_an_admin_user : given.no_user_authenticated

--- a/Sample/NUnit/when_doing_something_successful.cs
+++ b/Sample/NUnit/when_doing_something_successful.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample;
 
 public class when_doing_something_successful

--- a/Sample/NUnit/when_doing_something_that_fails.cs
+++ b/Sample/NUnit/when_doing_something_that_fails.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample;
 
 public class when_doing_something_that_fails

--- a/Sample/XUnit/GlobalUsings.cs
+++ b/Sample/XUnit/GlobalUsings.cs
@@ -1,2 +1,5 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 global using Cratis.Specifications;
 global using Xunit;

--- a/Sample/XUnit/for_SecurityService/given/no_user_authenticated.cs
+++ b/Sample/XUnit/for_SecurityService/given/no_user_authenticated.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityService.given;
 
 public class no_user_authenticated : Specification

--- a/Sample/XUnit/for_SecurityService/when_authenticating/a_null_user.cs
+++ b/Sample/XUnit/for_SecurityService/when_authenticating/a_null_user.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityService;
 
 public class When_authenticating_a_null_user : given.no_user_authenticated

--- a/Sample/XUnit/for_SecurityService/when_authenticating/an_admin_user.cs
+++ b/Sample/XUnit/for_SecurityService/when_authenticating/an_admin_user.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityService;
 
 public class When_authenticating_an_admin_user : given.no_user_authenticated

--- a/Sample/XUnit/for_SecurityServiceAsync/given/no_user_authenticated.cs
+++ b/Sample/XUnit/for_SecurityServiceAsync/given/no_user_authenticated.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityServiceAsync.given;
 
 public class no_user_authenticated : Specification

--- a/Sample/XUnit/for_SecurityServiceAsync/when_authenticating/a_null_user.cs
+++ b/Sample/XUnit/for_SecurityServiceAsync/when_authenticating/a_null_user.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityServiceAsync;
 
 public class When_authenticating_a_null_user : given.no_user_authenticated

--- a/Sample/XUnit/for_SecurityServiceAsync/when_authenticating/a_null_user_async.cs
+++ b/Sample/XUnit/for_SecurityServiceAsync/when_authenticating/a_null_user_async.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityServiceAsync;
 
 public class When_authenticating_a_null_user_async : given.no_user_authenticated

--- a/Sample/XUnit/for_SecurityServiceAsync/when_authenticating/an_admin_user.cs
+++ b/Sample/XUnit/for_SecurityServiceAsync/when_authenticating/an_admin_user.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample.for_SecurityServiceAsync;
 
 public class When_authenticating_an_admin_user : given.no_user_authenticated

--- a/Sample/XUnit/when_doing_something_successful.cs
+++ b/Sample/XUnit/when_doing_something_successful.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample;
 
 public class when_doing_something_successful

--- a/Sample/XUnit/when_doing_something_that_fails.cs
+++ b/Sample/XUnit/when_doing_something_that_fails.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Sample;
 
 public class when_doing_something_that_fails

--- a/Source/NUnit/ShouldCollectionExtensions.cs
+++ b/Source/NUnit/ShouldCollectionExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections;
 using NUnit.Framework;
 

--- a/Source/NUnit/ShouldComparableExtensions.cs
+++ b/Source/NUnit/ShouldComparableExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using NUnit.Framework;
 
 namespace Cratis.Specifications;

--- a/Source/NUnit/ShouldEqualityExtensions.cs
+++ b/Source/NUnit/ShouldEqualityExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using NUnit.Framework;
 
 namespace Cratis.Specifications;

--- a/Source/NUnit/ShouldStringExtensions.cs
+++ b/Source/NUnit/ShouldStringExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using NUnit.Framework;
 
 namespace Cratis.Specifications;

--- a/Source/NUnit/ShouldTypeExtensions.cs
+++ b/Source/NUnit/ShouldTypeExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using NUnit.Framework;
 
 namespace Cratis.Specifications;

--- a/Source/NUnit/Specification.cs
+++ b/Source/NUnit/Specification.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using NUnit.Framework;
 

--- a/Source/Specifications/Catch.cs
+++ b/Source/Specifications/Catch.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #nullable disable
 
 namespace Cratis.Specifications;

--- a/Source/Specifications/SpecificationCancelledException.cs
+++ b/Source/Specifications/SpecificationCancelledException.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Specifications;
+
+/// <summary>
+/// The exception that is thrown when a specification lifecycle method (Establish, Because, or Destroy)
+/// is cancelled before it completes — typically because a polling wait exceeded its timeout.
+/// </summary>
+/// <param name="phase">The lifecycle phase that was cancelled (Establish, Because, or Destroy).</param>
+/// <param name="innerException">The original cancellation exception.</param>
+public class SpecificationCancelledException(string phase, OperationCanceledException innerException)
+    : Exception(
+        $"{phase}() was cancelled before completing. This usually means a polling wait " +
+        "(e.g. WaitTillActive, WaitForState, WaitTillReachesEventSequenceNumber) exceeded its timeout. " +
+        "Consider increasing the timeout via CHRONICLE_TEST_TIMEOUT_SECONDS or passing an explicit timeout.",
+        innerException)
+{
+}

--- a/Source/Specifications/SpecificationMethods.cs
+++ b/Source/Specifications/SpecificationMethods.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 
 namespace Cratis.Specifications;
@@ -49,30 +52,37 @@ public static class SpecificationMethods<T, TSpecBase>
     /// </summary>
     /// <param name="unit">Unit to invoke them on.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public static Task Establish(object unit) => InvokeMethods(_establish, unit);
+    public static Task Establish(object unit) => InvokeMethods(_establish, unit, "Establish");
 
     /// <summary>
     /// Invoke all Destroy methods.
     /// </summary>
     /// <param name="unit">Unit to invoke them on.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public static Task Destroy(object unit) => InvokeMethods(_destroy, unit);
+    public static Task Destroy(object unit) => InvokeMethods(_destroy, unit, "Destroy");
 
     /// <summary>
     /// Invoke all Because methods.
     /// </summary>
     /// <param name="unit">Unit to invoke them on.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public static Task Because(object unit) => InvokeMethods(_because, unit);
+    public static Task Because(object unit) => InvokeMethods(_because, unit, "Because");
 
-    static async Task InvokeMethods(IEnumerable<MethodInfo> methods, object unit)
+    static async Task InvokeMethods(IEnumerable<MethodInfo> methods, object unit, string phase)
     {
         foreach (var method in methods)
         {
-            var result = method.Invoke(unit, []);
-            if (result is Task taskResult)
+            try
             {
-                await taskResult;
+                var result = method.Invoke(unit, []);
+                if (result is Task taskResult)
+                {
+                    await taskResult;
+                }
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new SpecificationCancelledException(phase, ex);
             }
         }
     }

--- a/Source/XUnit/ShouldCollectionExtensions.cs
+++ b/Source/XUnit/ShouldCollectionExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections;
 using Xunit;
 

--- a/Source/XUnit/ShouldComparableExtensions.cs
+++ b/Source/XUnit/ShouldComparableExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Xunit;
 
 namespace Cratis.Specifications;

--- a/Source/XUnit/ShouldEqualityExtensions.cs
+++ b/Source/XUnit/ShouldEqualityExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Xunit;
 
 namespace Cratis.Specifications;

--- a/Source/XUnit/ShouldStringExtensions.cs
+++ b/Source/XUnit/ShouldStringExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Xunit;
 
 namespace Cratis.Specifications;

--- a/Source/XUnit/ShouldTypeExtensions.cs
+++ b/Source/XUnit/ShouldTypeExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Xunit;
 
 namespace Cratis.Specifications;
@@ -14,7 +17,9 @@ public static class ShouldTypeExtensions
     /// <typeparam name="T">Type it should be assignable from.</typeparam>
     public static void ShouldBeAssignableFrom<T>(this object actual)
     {
+#pragma warning disable xUnit2032
         Assert.IsAssignableFrom<T>(actual);
+#pragma warning restore xUnit2032
     }
 
     /// <summary>
@@ -24,7 +29,9 @@ public static class ShouldTypeExtensions
     /// <param name="expected">Type it should be assignable from.</param>
     public static void ShouldBeAssignableFrom(this object actual, Type expected)
     {
+#pragma warning disable xUnit2032
         Assert.IsAssignableFrom(expected, actual);
+#pragma warning restore xUnit2032
     }
 
     /// <summary>

--- a/Source/XUnit/Specification.cs
+++ b/Source/XUnit/Specification.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Reflection;
 using Xunit;
 


### PR DESCRIPTION
## Fixed
- Release build was broken: all source and sample files were missing the required copyright header, causing `IDE0073` to be treated as an error under `TreatWarningsAsErrors=true`. Added the standard Cratis header to 37 affected files.
- `ShouldBeAssignableFrom` triggered the `xUnit2032` analyzer warning in Release. Suppressed with `#pragma warning disable/restore` since the suggested `Assert.IsType(..., exact: false)` overload only exists in xUnit v3 (this project targets v2.9.3).

## Added
- `SpecificationCancelledException` — thrown when `Establish()`, `Because()`, or `Destroy()` is cancelled before completing (e.g. a `WaitTillActive` or `WaitForState` polling wait exceeds its timeout). The message names the lifecycle phase and directs the reader to increase `CHRONICLE_TEST_TIMEOUT_SECONDS` or pass an explicit timeout. Previously the failure surfaced as an opaque `TaskCanceledException: A task was canceled.` with no actionable context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)