### PR TITLE
Upgrade targets to net8 baseline and net10 samples

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>  
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net48</TargetFrameworks>
+        <TargetFrameworks>net8.0;net48</TargetFrameworks>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);CS1591;RCS1090;CA2252;CS8632;RCS1217;SA1633;CA2007</NoWarn>

--- a/Sample/NUnit/Sample.NUnit.csproj
+++ b/Sample/NUnit/Sample.NUnit.csproj
@@ -3,9 +3,9 @@
         <AssemblyName>Cratis.Specifications.Sample.NUnit</AssemblyName>
         <RootNamespace>Cratis.Specifications.Sample</RootNamespace>
         <IsTestProject>true</IsTestProject>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <Nullable>disable</Nullable>
-        <NoWarn>$(NoWarn);CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134;MA0048;CA1002;MA0016</NoWarn>
+        <NoWarn>$(NoWarn);CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134;MA0048;CA1002;MA0016;CA1515</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Sample/XUnit/Sample.XUnit.csproj
+++ b/Sample/XUnit/Sample.XUnit.csproj
@@ -3,9 +3,9 @@
         <AssemblyName>Cratis.Specifications.Sample.XUnit</AssemblyName>
         <RootNamespace>Cratis.Specifications.Sample</RootNamespace>
         <IsTestProject>true</IsTestProject>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <Nullable>disable</Nullable>
-        <NoWarn>$(NoWarn);CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134;MA0048;CA1002;MA0016</NoWarn>
+        <NoWarn>$(NoWarn);CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134;MA0048;CA1002;MA0016;CA1515</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/NUnit/NUnit.csproj
+++ b/Source/NUnit/NUnit.csproj
@@ -4,7 +4,7 @@
         <RootNamespace>Cratis.Specifications</RootNamespace>
         <IsPackable>true</IsPackable>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net6.0;net48</TargetFrameworks>
+        <TargetFrameworks>net8.0;net48</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/Specifications/SpecificationMethods.cs
+++ b/Source/Specifications/SpecificationMethods.cs
@@ -87,7 +87,7 @@ public static class SpecificationMethods<T, TSpecBase>
         }
     }
 
-    static IEnumerable<MethodInfo> GetMethodsFor(string name)
+    static List<MethodInfo> GetMethodsFor(string name)
     {
         var type = typeof(T);
         var methods = new List<MethodInfo>();

--- a/Source/XUnit/ShouldCollectionExtensions.cs
+++ b/Source/XUnit/ShouldCollectionExtensions.cs
@@ -24,13 +24,9 @@ public static class ShouldCollectionExtensions
 
         foreach (var item in expected)
         {
-            if (!source.Contains<T>(item))
+            if (!source.Remove(item))
             {
                 noContain.Add(item);
-            }
-            else
-            {
-                source.Remove(item);
             }
         }
 


### PR DESCRIPTION
## Changed
- Updated the shared target framework baseline from netstandard2.1 to net8.0 while keeping net48 multi-targeting.
- Retargeted sample NUnit and XUnit projects from net6.0 to net10.0.

## Fixed
- Removed package compatibility warnings by aligning sample targets with modern adapter-compatible frameworks.
- Applied minimal analyzer-safe code adjustments required for clean release builds after retargeting.