### PR TITLE
Fix publish workflow: update SDK to .NET 10 and suppress NU1701

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup .Net
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "6.0.400"
+          dotnet-version: "10.0.x"
       - name: Build
         run: dotnet build --configuration Release
 

--- a/Sample/NUnit/Sample.NUnit.csproj
+++ b/Sample/NUnit/Sample.NUnit.csproj
@@ -5,7 +5,7 @@
         <IsTestProject>true</IsTestProject>
         <TargetFrameworks>net10.0</TargetFrameworks>
         <Nullable>disable</Nullable>
-        <NoWarn>$(NoWarn);CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134;MA0048;CA1002;MA0016;CA1515</NoWarn>
+        <NoWarn>$(NoWarn);CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134;MA0048;CA1002;MA0016;CA1515;NU1701</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Sample/XUnit/Sample.XUnit.csproj
+++ b/Sample/XUnit/Sample.XUnit.csproj
@@ -5,7 +5,7 @@
         <IsTestProject>true</IsTestProject>
         <TargetFrameworks>net10.0</TargetFrameworks>
         <Nullable>disable</Nullable>
-        <NoWarn>$(NoWarn);CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134;MA0048;CA1002;MA0016;CA1515</NoWarn>
+        <NoWarn>$(NoWarn);CA1707;CS1591;RCS1213;IDE0051;IDE1006;CA1051;SA1633;RCS1090;SA1649;SA1600;SA1310;SA1502;SA1134;MA0048;CA1002;MA0016;CA1515;NU1701</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Fixed
- Publish CI has been broken since March 2026: the workflow installed .NET SDK 6.0.400 while `global.json` requires .NET 10, causing test runner packages to restore with `.NETFramework` compatibility shims and fail under `TreatWarningsAsErrors=true` (NU1701). Updated the workflow to use `10.0.x`.
- Added `NU1701` to `NoWarn` in both sample projects so the compatibility shim warning from test runner packages that lack explicit `net10.0` targets does not break the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)