### PR TITLE
Fix publish workflow failing to create GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      # Required for the release action to create a GitHub release and push tags
+      contents: write
       # Required for NuGet trusted publishing using OIDC tokens
       id-token: write
 


### PR DESCRIPTION
## Fixed

- The publish workflow now grants `contents: write` so the release step can create the GitHub release and push its tag. Previously the job declared only `id-token: write` (for NuGet OIDC), which defaulted every other permission to `none`, causing the release step to fail with `403 Resource not accessible by integration`.